### PR TITLE
Fixes for the undefined enum and stale file handle leftover when opening a ".tags" file.

### DIFF
--- a/src/fuse_operations/open.c
+++ b/src/fuse_operations/open.c
@@ -50,6 +50,9 @@ int tagsistant_open(const char *path, struct fuse_file_info *fi)
 	else if (QTREE_POINTS_TO_OBJECT(qtree)) {
 		if (tagsistant_is_tags_list_file(qtree)) {
 			res = open(tagsistant.tags, fi->flags);
+			if(res isNot -1) {
+				tagsistant_set_file_handle(fi, res);
+			}
 			tagsistant_errno = errno;
 			goto TAGSISTANT_EXIT_OPERATION;
 		}

--- a/src/fuse_operations/release.c
+++ b/src/fuse_operations/release.c
@@ -43,9 +43,12 @@ int tagsistant_release(const char *path, struct fuse_file_info *fi)
 	tagsistant_querytree_check_tagging_consistency(qtree);
 
 	// -- object --
-	if (QTREE_IS_TAGGABLE(qtree) && fi->fh) {
+	if(fi->fh &&
+	   (QTREE_IS_TAGGABLE(qtree) ||
+	     (QTREE_POINTS_TO_OBJECT(qtree) && tagsistant_is_tags_list_file(qtree)))) {
 		dbg('F', LOG_INFO, "Uncaching %" PRIu64 " = open(%s)", fi->fh, path);
-		close(fi->fh);
+		res = close(fi->fh);
+		tagsistant_errno = errno;
 		fi->fh = 0;
 	}
 

--- a/src/path_resolution.h
+++ b/src/path_resolution.h
@@ -23,7 +23,7 @@
 /**
  * Triple tag operators
  */
-enum {
+typedef enum {
 	TAGSISTANT_NONE,
 	TAGSISTANT_EQUAL_TO,
 	TAGSISTANT_CONTAINS,


### PR DESCRIPTION
Two commits that fix:
 * the undefined enum today's compilers do not like,
 *  and stale file handle leftover when opening a ".tags" file.

The latter can be tested by watching the /proc/$PID/fd directory before and after opening and closing a ".tags" file. Doing this thousands of times exhausts your session's file handles until now.